### PR TITLE
build: Fix a race condition while building the recovery patch (needed…

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1201,6 +1201,31 @@ $(INSTALLED_RECOVERYIMAGE_TARGET): $(MKBOOTIMG) $(recovery_ramdisk) $(recovery_k
 	$(call build-recoveryimage-target, $@)
 endif # BOARD_CUSTOM_BOOTIMG_MK
 
+# The system partition needs room for the recovery image as well.  We
+# now store the recovery image as a binary patch using the boot image
+# as the source (since they are very similar).  Generate the patch so
+# we can see how big it's going to be, and include that in the system
+# image size check calculation.
+ifneq ($(INSTALLED_RECOVERYIMAGE_TARGET),)
+intermediates := $(call intermediates-dir-for,PACKAGING,recovery_patch)
+ifndef BOARD_CANT_BUILD_RECOVERY_FROM_BOOT_PATCH
+RECOVERY_FROM_BOOT_PATCH := $(intermediates)/recovery_from_boot.p
+else
+RECOVERY_FROM_BOOT_PATCH :=
+endif
+$(RECOVERY_FROM_BOOT_PATCH): $(INSTALLED_RECOVERYIMAGE_TARGET) \
+                             $(INSTALLED_BOOTIMAGE_TARGET) \
+			     $(HOST_OUT_EXECUTABLES)/imgdiff \
+	                     $(HOST_OUT_EXECUTABLES)/bsdiff
+	@echo -e ${CL_CYN}"Construct recovery from boot"${CL_RST}
+	mkdir -p $(dir $@)
+ifeq ($(TARGET_NOT_USE_GZIP_RECOVERY_RAMDISK),true)
+	PATH=$(HOST_OUT_EXECUTABLES):$$PATH $(HOST_OUT_EXECUTABLES)/bsdiff $(INSTALLED_BOOTIMAGE_TARGET) $(INSTALLED_RECOVERYIMAGE_TARGET) $@
+else
+	PATH=$(HOST_OUT_EXECUTABLES):$$PATH $(HOST_OUT_EXECUTABLES)/imgdiff $(INSTALLED_BOOTIMAGE_TARGET) $(INSTALLED_RECOVERYIMAGE_TARGET) $@
+endif
+endif
+
 ifdef RECOVERY_RESOURCE_ZIP
 $(RECOVERY_RESOURCE_ZIP): $(INSTALLED_RECOVERYIMAGE_TARGET) | $(ZIPTIME)
 	$(hide) mkdir -p $(dir $@)
@@ -1361,36 +1386,6 @@ endif
 
 INSTALLED_SYSTEMIMAGE := $(PRODUCT_OUT)/system.img
 SYSTEMIMAGE_SOURCE_DIR := $(TARGET_OUT)
-
-# The system partition needs room for the recovery image as well.  We
-# now store the recovery image as a binary patch using the boot image
-# as the source (since they are very similar).  Generate the patch so
-# we can see how big it's going to be, and include that in the system
-# image size check calculation.
-ifneq ($(INSTALLED_RECOVERYIMAGE_TARGET),)
-ifneq ($(BOARD_USES_FULL_RECOVERY_IMAGE),true)
-intermediates := $(call intermediates-dir-for,PACKAGING,recovery_patch)
-ifndef BOARD_CANT_BUILD_RECOVERY_FROM_BOOT_PATCH
-RECOVERY_FROM_BOOT_PATCH := $(intermediates)/recovery_from_boot.p
-else
-RECOVERY_FROM_BOOT_PATCH :=
-endif
-$(RECOVERY_FROM_BOOT_PATCH): $(INSTALLED_RECOVERYIMAGE_TARGET) \
-                             $(INSTALLED_BOOTIMAGE_TARGET) \
-			     $(HOST_OUT_EXECUTABLES)/imgdiff \
-	                     $(HOST_OUT_EXECUTABLES)/bsdiff
-	@echo "Construct recovery from boot"
-	mkdir -p $(dir $@)
-ifeq ($(TARGET_NOT_USE_GZIP_RECOVERY_RAMDISK),true)
-	PATH=$(HOST_OUT_EXECUTABLES):$$PATH $(HOST_OUT_EXECUTABLES)/bsdiff $(INSTALLED_BOOTIMAGE_TARGET) $(INSTALLED_RECOVERYIMAGE_TARGET) $@
-else
-	PATH=$(HOST_OUT_EXECUTABLES):$$PATH $(HOST_OUT_EXECUTABLES)/imgdiff $(INSTALLED_BOOTIMAGE_TARGET) $(INSTALLED_RECOVERYIMAGE_TARGET) $@
-endif
-else # $(BOARD_USES_FULL_RECOVERY_IMAGE) == true
-RECOVERY_FROM_BOOT_PATCH := $(INSTALLED_RECOVERYIMAGE_TARGET)
-endif
-endif
-
 
 $(INSTALLED_SYSTEMIMAGE): $(BUILT_SYSTEMIMAGE) $(RECOVERY_FROM_BOOT_PATCH) | $(ACP)
 	@echo "Install system fs image: $@"


### PR DESCRIPTION
… for msm8226)

RECOVERY_PATCH_INSTALL has a dependency on RECOVERY_FROM_BOOT_PATCH.
This is correct, because RECOVERY_PATCH_INSTALL uses make_recovery_patch
which needs the imgdiff tool. imgdiff on the other hand is a dependency
of RECOVERY_FROM_BOOT_PATCH. This should ensure that all dependencies
are met.
However, RECOVERY_FROM_BOOT_PATCH is defined after
RECOVERY_PATCH_INSTALL, making the dependency effectively non-existant.
Moving RECOVERY_FROM_BOOT_PATCH before RECOVERY_PATCH_INSTALL fixes a
race-condition where sometimes imgdiff was not build before
RECOVERY_PATCH_INSTALL is called.

Upstream is not affected by this bug, since it does not contain
RECOVERY_PATCH_INSTALL anymore.

The following error can be observed whenever someone hits this race
condition (which is basically always reproducible when building with
-j1):
Installing recovery patch to system partition
Warning: could not find SYSTEM/build.prop in <built-in function zip>
using prebuilt recovery.img from BOOTABLE_IMAGES...
using prebuilt boot.img from BOOTABLE_IMAGES...
Traceback (most recent call last):
  File "./build/tools/releasetools/make_recovery_patch", line 55, in <module>
    main(sys.argv[1:])
  File "./build/tools/releasetools/make_recovery_patch", line 51, in main
    common.MakeRecoveryPatch(input_dir, output_sink, recovery_img, boot_img)
  File "build/tools/releasetools/common.py", line 1461, in MakeRecoveryPatch
    _, _, patch = d.ComputePatch()
  File "build/tools/releasetools/common.py", line 1146, in ComputePatch
    p = Run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "build/tools/releasetools/common.py", line 100, in Run
    return subprocess.Popen(args, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
build/core/Makefile:1047: recipe for target
    'out/target/product/t00n/system/bin/install-recovery.sh' failed

Fixes: 3d1c612e5c82 ("Revert "Revert "core: Makefile: Build
install-recovery into the system image""")

Change-Id: I28e8c845ffc830553ca5177cbe22ae72b185b437